### PR TITLE
Move babel into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
   "dependencies": {
     "applicationinsights-js": "^1.0.3",
     "away": "^1.0.0",
-    "babel-cli": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0",
     "remove-value": "^1.0.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.14.0",
+    "babel-preset-es2015": "^6.14.0"
   }
 }


### PR DESCRIPTION
Babel preset and cli are used only for compiling and as such are better suited in devDependencies.  